### PR TITLE
Add basic GUI and scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENT Instructions
+
+This repository contains the BTtoAUX project. It provides a simple GUI written in Python (`src/main.py`) that is intended to run on a Raspberry Pi 4 with a 320x480 touch screen. The GUI shows track information and basic playback controls. Bluetooth integration is **not** fully implemented yet; the current code only provides placeholders.
+
+## Coding Guidelines
+
+- Keep all source code in the `src/` directory.
+- Use Python 3.7+ compatible syntax.
+- Use PEP8 style where possible.
+- When modifying or adding scripts, update this `AGENTS.md` file accordingly.
+- Always run `flake8` and `python -m py_compile` on any added Python files when possible.
+
+## Programmatic Checks
+
+Run the following commands before committing:
+
+```bash
+flake8 src/main.py
+python -m py_compile src/main.py
+```
+
+These checks ensure the code is syntactically correct and roughly follows style guidelines. If `flake8` is not installed, it can be installed with `pip install flake8`.
+
+## Pull Request Notes
+
+Include a summary of changes and test results in the PR description. Mention any limitations or manual steps required for setup.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # BTtoAUX
+
+BTtoAUX provides a graphical interface to play audio from any Bluetooth device through the Raspberry Pi's audio output. It is designed for a 320x480 touch display and works on the Raspberry Pi 4.
+
+## Features
+
+- Bluetooth pairing with PIN confirmation
+- Display of connected device, track title and artist
+- Playback controls: previous, play/pause, next
+- Progress indicator and remaining time
+- Volume control
+- Update script to fetch the latest version from GitHub
+
+## Requirements
+
+- Raspberry Pi 4 running Raspberry Pi OS
+- 320x480 touch display
+- Internet connection for updates
+
+## Installation
+
+Run the included `install.sh` script to install all dependencies:
+
+```bash
+bash install.sh
+```
+
+Start the GUI with:
+
+```bash
+python3 src/main.py
+```
+
+## Updating
+
+Use `update.sh` to check for and download newer versions from GitHub:
+
+```bash
+bash update.sh
+```
+
+## Disclaimer
+
+This project currently provides a basic GUI. Integration with Bluetooth audio and system services requires additional setup that is not included here.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Install dependencies for BTtoAUX
+set -e
+sudo apt-get update
+sudo apt-get install -y python3 python3-pip python3-tk git bluez pulseaudio
+
+# Install Python packages if any
+pip3 install --upgrade pip
+pip3 install --upgrade pybluez
+
+cat <<MSG
+Installation complete. Use 'python3 src/main.py' to start the GUI.
+MSG

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,129 @@
+import tkinter as tk
+from tkinter import ttk
+
+
+class BTtoAUXApp(tk.Tk):
+    """Simple Bluetooth audio GUI for 320x480 px touch display."""
+    WIDTH = 320
+    HEIGHT = 480
+
+    def __init__(self):
+        super().__init__()
+        self.title("BTtoAUX")
+        self.geometry(f"{self.WIDTH}x{self.HEIGHT}")
+        self.configure(bg="#222222")
+        self.create_widgets()
+        # Placeholder state variables
+        self.connected_device = tk.StringVar(value="No device")
+        self.track_title = tk.StringVar(value="-")
+        self.track_artist = tk.StringVar(value="-")
+        self.track_progress = tk.DoubleVar(value=0.0)
+        self.track_length = tk.StringVar(value="0:00")
+        self.pin_request = tk.StringVar(value="")
+
+    def create_widgets(self):
+        # Connection status
+        status_label = tk.Label(
+            self,
+            textvariable=self.connected_device,
+            fg="white",
+            bg="#444",
+            font=("Arial", 12),
+        )
+        status_label.pack(fill="x", pady=5)
+
+        # Track info frame
+        info_frame = tk.Frame(self, bg="#222")
+        info_frame.pack(fill="x", pady=10)
+        tk.Label(
+            info_frame,
+            textvariable=self.track_title,
+            fg="white",
+            bg="#222",
+            font=("Arial", 14, "bold"),
+        ).pack()
+        tk.Label(
+            info_frame,
+            textvariable=self.track_artist,
+            fg="gray",
+            bg="#222",
+            font=("Arial", 12),
+        ).pack()
+
+        # Progress bar
+        progress = ttk.Progressbar(
+            self,
+            variable=self.track_progress,
+            maximum=100,
+        )
+        progress.pack(fill="x", padx=20)
+        self.time_label = tk.Label(
+            self,
+            text="0:00 / 0:00",
+            fg="white",
+            bg="#222",
+        )
+        self.time_label.pack(pady=5)
+
+        # Control buttons
+        controls = tk.Frame(self, bg="#222")
+        controls.pack(pady=10)
+        self.prev_btn = tk.Button(controls, text="⏮", width=5)
+        self.play_btn = tk.Button(controls, text="⏯", width=5)
+        self.next_btn = tk.Button(controls, text="⏭", width=5)
+        self.prev_btn.grid(row=0, column=0, padx=5)
+        self.play_btn.grid(row=0, column=1, padx=5)
+        self.next_btn.grid(row=0, column=2, padx=5)
+
+        # Volume slider
+        volume_frame = tk.Frame(self, bg="#222")
+        volume_frame.pack(fill="x")
+        tk.Label(
+            volume_frame,
+            text="Volume",
+            fg="white",
+            bg="#222",
+        ).pack(side="left", padx=10)
+        self.volume = tk.Scale(
+            volume_frame,
+            from_=0,
+            to=100,
+            orient="horizontal",
+            length=180,
+            bg="#222",
+            fg="white",
+        )
+        self.volume.pack(side="left")
+
+        # PIN entry
+        self.pin_frame = tk.Frame(self, bg="#222")
+        self.pin_label = tk.Label(
+            self.pin_frame,
+            text="Enter PIN: ",
+            fg="white",
+            bg="#222",
+        )
+        self.pin_entry = tk.Entry(self.pin_frame)
+        self.pin_button = tk.Button(self.pin_frame, text="Confirm")
+        self.pin_label.pack(side="left")
+        self.pin_entry.pack(side="left")
+        self.pin_button.pack(side="left")
+
+    def show_pin_request(self, pin):
+        self.pin_request.set(pin)
+        self.pin_frame.pack(pady=10)
+
+    def hide_pin_request(self):
+        self.pin_frame.pack_forget()
+
+    def update_time(self, current, total):
+        self.time_label.config(text=f"{current} / {total}")
+
+
+def main():
+    app = BTtoAUXApp()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Check GitHub for newer version and update if available
+REPO="https://api.github.com/repos/studio-justin-braun/BTtoAUX"
+LOCAL_VERSION=$(git rev-parse HEAD)
+REMOTE_VERSION=$(curl -s $REPO/commits/main | grep sha | head -n 1 | cut -d '"' -f4)
+
+echo "Local version: $LOCAL_VERSION"
+echo "Remote version: $REMOTE_VERSION"
+
+if [ "$LOCAL_VERSION" != "$REMOTE_VERSION" ]; then
+    echo "Updating to latest version..."
+    git pull --rebase origin main
+    echo "Update finished."
+else
+    echo "Already up to date."
+fi


### PR DESCRIPTION
## Summary
- implement a simple Tkinter interface sized for a 320x480 display
- add installation and update helper scripts
- document usage in English README
- define contributor guidelines in AGENTS.md

## Testing
- `flake8 src/main.py`
- `python -m py_compile src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686a5c5e1f488326a611fe8303738ea2