### PR TITLE
Fix init ordering and remove pybluez install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,10 @@ sudo apt-get install -y python3 python3-pip python3-tk git bluez pulseaudio
 
 # Install Python packages if any
 pip3 install --break-system-packages --upgrade pip
-pip3 install --break-system-packages --upgrade pybluez
+# PyBluez is not installed automatically due to incompatibility with
+# newer Python versions. Install manually if needed.
 
 cat <<MSG
 Installation complete. Use 'python3 src/main.py' to start the GUI.
 MSG
+

--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,6 @@ class BTtoAUXApp(tk.Tk):
         self.title("BTtoAUX")
         self.geometry(f"{self.WIDTH}x{self.HEIGHT}")
         self.configure(bg="#222222")
-        self.create_widgets()
         # Placeholder state variables
         self.connected_device = tk.StringVar(value="No device")
         self.track_title = tk.StringVar(value="-")
@@ -20,6 +19,8 @@ class BTtoAUXApp(tk.Tk):
         self.track_progress = tk.DoubleVar(value=0.0)
         self.track_length = tk.StringVar(value="0:00")
         self.pin_request = tk.StringVar(value="")
+
+        self.create_widgets()
 
     def create_widgets(self):
         # Connection status


### PR DESCRIPTION
## Summary
- fix initialization order so `StringVar` widgets exist before `create_widgets()`
- remove pybluez from install script since it fails on newer Python

## Testing
- `flake8 src/main.py`
- `python -m py_compile src/main.py`


------
https://chatgpt.com/codex/tasks/task_e_686a5f88b8108326b763d61416ea1c86