### PR TITLE
Add Bluetooth audio sink setup helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ This repository contains the BTtoAUX project. It provides a simple GUI written i
 - Use Python 3.7+ compatible syntax.
 - Use PEP8 style where possible.
 - When modifying or adding scripts, update this `AGENTS.md` file accordingly.
+  The project root contains helper shell scripts such as `install.sh`,
+  `update.sh` and `setup_bt_sink.sh`.
 - Always run `flake8` and `python -m py_compile` on any added Python files when possible.
 
 ## Programmatic Checks

--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ Use `update.sh` to check for and download newer versions from GitHub:
 bash update.sh
 ```
 
+### Bluetooth Audio Sink Setup
+
+To stream audio from a smartphone via Bluetooth and output it on the Pi's
+3.5&nbsp;mm jack, run:
+
+```bash
+bash setup_bt_sink.sh
+```
+
+The script installs required packages, starts PulseAudio and makes the Pi
+discoverable. After pairing your phone, any audio will be played through the
+AUX port.
+
 ## Disclaimer
 
 This project currently provides a basic GUI. Integration with Bluetooth audio and system services requires additional setup that is not included here.

--- a/setup_bt_sink.sh
+++ b/setup_bt_sink.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Configure Raspberry Pi as Bluetooth A2DP sink and route audio to 3.5mm jack
+# This script installs necessary packages, starts PulseAudio, and enables
+# Bluetooth pairing for a smartphone. Run once after boot.
+
+set -e
+
+# Install required packages
+sudo apt-get update
+sudo apt-get install -y pulseaudio pulseaudio-module-bluetooth bluez-utils
+
+# Ensure PulseAudio is running
+if ! pgrep -x pulseaudio >/dev/null; then
+    pulseaudio --start
+fi
+
+# Set audio output to analog 3.5mm jack
+if command -v amixer >/dev/null; then
+    sudo amixer cset numid=3 1 || true
+fi
+
+# Load Bluetooth modules for PulseAudio
+pactl unload-module module-bluetooth-discover 2>/dev/null || true
+pactl load-module module-bluetooth-discover
+pactl unload-module module-bluetooth-policy 2>/dev/null || true
+pactl load-module module-bluetooth-policy
+
+# Enable discoverable & pairable mode
+bluetoothctl <<BTPAIR
+power on
+agent on
+default-agent
+discoverable on
+pairable on
+BTPAIR
+
+echo "Raspberry Pi ready for Bluetooth pairing. Connect from your smartphone and play audio."


### PR DESCRIPTION
## Summary
- add helper script `setup_bt_sink.sh` to configure the Pi as a Bluetooth A2DP sink
- document the new script in README
- update AGENTS instructions mentioning the helper scripts

## Testing
- `flake8 src/main.py`
- `python -m py_compile src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686a6339a49c8326b536b2bf95818b91